### PR TITLE
docs: document auth endpoints

### DIFF
--- a/src/main/java/com/example/usermanagement/controller/AuthController.java
+++ b/src/main/java/com/example/usermanagement/controller/AuthController.java
@@ -2,6 +2,11 @@ package com.example.usermanagement.controller;
 
 import com.example.usermanagement.dto.*;
 import com.example.usermanagement.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
@@ -15,22 +20,119 @@ public class AuthController {
     private UserService userService;
 
     @PostMapping("/register")
-    public UserResponse register(@RequestBody RegisterRequest request) {
+    @Operation(
+        summary = "Registrar un nuevo usuario",
+        description = "Crea una cuenta con los datos proporcionados"
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "Usuario registrado",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = UserResponse.class)
+            )
+        ),
+        @ApiResponse(responseCode = "400", description = "Datos inválidos", content = @Content),
+        @ApiResponse(responseCode = "409", description = "El usuario ya existe", content = @Content)
+    })
+    public UserResponse register(
+        @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            description = "Datos de registro del usuario",
+            required = true,
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = RegisterRequest.class)
+            )
+        )
+        @RequestBody RegisterRequest request
+    ) {
         return userService.register(request);
     }
 
     @PostMapping("/login")
-    public String login(@RequestBody LoginRequest request) {
+    @Operation(
+        summary = "Iniciar sesión",
+        description = "Autentica al usuario y devuelve un token JWT"
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "Autenticación exitosa",
+            content = @Content(
+                mediaType = "text/plain",
+                schema = @Schema(implementation = String.class)
+            )
+        ),
+        @ApiResponse(responseCode = "400", description = "Credenciales inválidas", content = @Content),
+        @ApiResponse(responseCode = "401", description = "No autorizado", content = @Content)
+    })
+    public String login(
+        @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            description = "Credenciales del usuario (username y password)",
+            required = true,
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = LoginRequest.class)
+            )
+        )
+        @RequestBody LoginRequest request
+    ) {
         return userService.login(request);
     }
 
     @PostMapping("/forgot")
-    public String forgotPassword(@RequestBody ForgotPasswordRequest request) {
+    @Operation(
+        summary = "Solicitar restablecimiento de contraseña",
+        description = "Genera un token para restablecer la contraseña"
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "Solicitud aceptada",
+            content = @Content(
+                mediaType = "text/plain",
+                schema = @Schema(implementation = String.class)
+            )
+        ),
+        @ApiResponse(responseCode = "400", description = "Datos inválidos", content = @Content),
+        @ApiResponse(responseCode = "404", description = "Usuario no encontrado", content = @Content)
+    })
+    public String forgotPassword(
+        @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            description = "Correo electrónico del usuario",
+            required = true,
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ForgotPasswordRequest.class)
+            )
+        )
+        @RequestBody ForgotPasswordRequest request
+    ) {
         return userService.forgotPassword(request);
     }
 
     @PostMapping("/reset")
-    public void resetPassword(@RequestBody ResetPasswordRequest request) {
+    @Operation(
+        summary = "Restablecer contraseña",
+        description = "Establece una nueva contraseña usando el token recibido"
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Contraseña restablecida", content = @Content),
+        @ApiResponse(responseCode = "400", description = "Datos inválidos", content = @Content),
+        @ApiResponse(responseCode = "404", description = "Token inválido", content = @Content)
+    })
+    public void resetPassword(
+        @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            description = "Token de restablecimiento y nueva contraseña",
+            required = true,
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ResetPasswordRequest.class)
+            )
+        )
+        @RequestBody ResetPasswordRequest request
+    ) {
         userService.resetPassword(request);
     }
 }


### PR DESCRIPTION
## Summary
- add OpenAPI operation, response and request body annotations to authentication endpoints

## Testing
- `mvn test` *(fails: Non-resolvable parent POM - Network is unreachable)*
- `mvn -q spring-boot:run` *(fails: Non-resolvable parent POM - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c6f88a90bc8323a384e977001bb52c