### PR TITLE
Move user registration to UserController

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Spring Boot 3 REST API for managing users with JWT security.
 
 ## Features
-- Register and login users with JWT authentication
+- User registration via `POST /api/users` and login with JWT authentication
 - CRUD operations for users (admin only)
 - Forgot and reset password flows
 - PostgreSQL database

--- a/src/main/java/com/example/usermanagement/controller/AuthController.java
+++ b/src/main/java/com/example/usermanagement/controller/AuthController.java
@@ -19,37 +19,6 @@ public class AuthController {
     @Autowired
     private UserService userService;
 
-    @PostMapping("/register")
-    @Operation(
-        summary = "Registrar un nuevo usuario",
-        description = "Crea una cuenta con los datos proporcionados"
-    )
-    @ApiResponses({
-        @ApiResponse(
-            responseCode = "200",
-            description = "Usuario registrado",
-            content = @Content(
-                mediaType = "application/json",
-                schema = @Schema(implementation = UserResponse.class)
-            )
-        ),
-        @ApiResponse(responseCode = "400", description = "Datos inválidos", content = @Content),
-        @ApiResponse(responseCode = "409", description = "El usuario ya existe", content = @Content)
-    })
-    public UserResponse register(
-        @io.swagger.v3.oas.annotations.parameters.RequestBody(
-            description = "Datos de registro del usuario",
-            required = true,
-            content = @Content(
-                mediaType = "application/json",
-                schema = @Schema(implementation = RegisterRequest.class)
-            )
-        )
-        @RequestBody RegisterRequest request
-    ) {
-        return userService.register(request);
-    }
-
     @PostMapping("/login")
     @Operation(
         summary = "Iniciar sesión",

--- a/src/main/java/com/example/usermanagement/controller/UserController.java
+++ b/src/main/java/com/example/usermanagement/controller/UserController.java
@@ -5,6 +5,8 @@ import com.example.usermanagement.dto.UserResponse;
 import com.example.usermanagement.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -22,6 +24,33 @@ public class UserController {
 
     @Autowired
     private UserService userService;
+
+    @PostMapping
+    @Operation(summary = "Crear un nuevo usuario")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Usuario creado",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = UserResponse.class)
+                    )
+            ),
+            @ApiResponse(responseCode = "400", description = "Datos inválidos", content = @Content),
+            @ApiResponse(responseCode = "409", description = "El usuario ya existe", content = @Content)
+    })
+    public UserResponse createUser(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "Datos de registro del usuario",
+                    required = true,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = RegisterRequest.class)
+                    )
+            )
+            @RequestBody RegisterRequest request) {
+        return userService.register(request);
+    }
 
     @GetMapping
     //@PreAuthorize("hasRole('ADMIN')")


### PR DESCRIPTION
## Summary
- remove user registration endpoint from `AuthController`
- add `POST /api/users` for user creation in `UserController`
- document user creation in README

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c701e0f93c83238ee67e6acc3da3d3