### PR TITLE
Move password reset endpoint to UserController

### DIFF
--- a/src/main/java/com/example/usermanagement/controller/AuthController.java
+++ b/src/main/java/com/example/usermanagement/controller/AuthController.java
@@ -80,28 +80,4 @@ public class AuthController {
     ) {
         return userService.forgotPassword(request);
     }
-
-    @PostMapping("/reset")
-    @Operation(
-        summary = "Restablecer contraseña",
-        description = "Establece una nueva contraseña usando el token recibido"
-    )
-    @ApiResponses({
-        @ApiResponse(responseCode = "200", description = "Contraseña restablecida", content = @Content),
-        @ApiResponse(responseCode = "400", description = "Datos inválidos", content = @Content),
-        @ApiResponse(responseCode = "404", description = "Token inválido", content = @Content)
-    })
-    public void resetPassword(
-        @io.swagger.v3.oas.annotations.parameters.RequestBody(
-            description = "Token de restablecimiento y nueva contraseña",
-            required = true,
-            content = @Content(
-                mediaType = "application/json",
-                schema = @Schema(implementation = ResetPasswordRequest.class)
-            )
-        )
-        @RequestBody ResetPasswordRequest request
-    ) {
-        userService.resetPassword(request);
-    }
 }

--- a/src/main/java/com/example/usermanagement/controller/UserController.java
+++ b/src/main/java/com/example/usermanagement/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.example.usermanagement.controller;
 
 import com.example.usermanagement.dto.RegisterRequest;
+import com.example.usermanagement.dto.ResetPasswordRequest;
 import com.example.usermanagement.dto.UserResponse;
 import com.example.usermanagement.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -52,6 +53,29 @@ public class UserController {
         return userService.register(request);
     }
 
+    @PostMapping("/reset")
+    @Operation(
+            summary = "Restablecer contraseña",
+            description = "Establece una nueva contraseña usando el token recibido"
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Contraseña restablecida", content = @Content),
+            @ApiResponse(responseCode = "400", description = "Datos inválidos", content = @Content),
+            @ApiResponse(responseCode = "404", description = "Token inválido", content = @Content)
+    })
+    public void resetPassword(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "Token de restablecimiento y nueva contraseña",
+                    required = true,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ResetPasswordRequest.class)
+                    )
+            )
+            @RequestBody ResetPasswordRequest request
+    ) {
+            userService.resetPassword(request);
+    }
     @GetMapping
     //@PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Lista todos los usuarios", security = @SecurityRequirement(name = "bearerAuth"))

--- a/src/main/java/com/example/usermanagement/security/SecurityConfig.java
+++ b/src/main/java/com/example/usermanagement/security/SecurityConfig.java
@@ -49,6 +49,8 @@ public class SecurityConfig {
                         ).permitAll()
                         // auth públicas
                         .requestMatchers("/api/auth/**").permitAll()
+                        // reset password pública
+                        .requestMatchers("/api/users/reset").permitAll()
                         // todo lo demás requiere token
                         .requestMatchers("/api/users/**").authenticated()
                         .anyRequest().authenticated()


### PR DESCRIPTION
## Summary
- remove password reset endpoint from `AuthController`
- add `/api/users/reset` endpoint in `UserController` with swagger docs
- allow public access to `/api/users/reset` in security config

## Testing
- `mvn -DskipTests package` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.4 - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c771e5125c8323a7f25fef99fd2cd1