### PR TITLE
Allow public user registration and reset endpoints

### DIFF
--- a/src/main/java/com/example/usermanagement/security/SecurityConfig.java
+++ b/src/main/java/com/example/usermanagement/security/SecurityConfig.java
@@ -13,6 +13,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.http.HttpMethod;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -49,6 +50,9 @@ public class SecurityConfig {
                         ).permitAll()
                         // auth públicas
                         .requestMatchers("/api/auth/**").permitAll()
+                        // registro y restablecimiento de usuarios
+                        .requestMatchers(HttpMethod.POST, "/api/users").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/users/reset").permitAll()
                         // todo lo demás requiere token
                         .requestMatchers("/api/users/**").authenticated()
                         .anyRequest().authenticated()


### PR DESCRIPTION
## Summary
- Allow POST /api/users and /api/users/reset without authentication for registration and password reset
- Keep other /api/users/** endpoints authenticated and confirm /api/auth/** remains public

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c771e9aa648323899eb7e3c3e774b0