### PR TITLE
Add ErrorResponse DTO and document error responses

### DIFF
--- a/src/main/java/com/example/usermanagement/controller/AuthController.java
+++ b/src/main/java/com/example/usermanagement/controller/AuthController.java
@@ -33,8 +33,22 @@ public class AuthController {
                 schema = @Schema(implementation = String.class)
             )
         ),
-        @ApiResponse(responseCode = "400", description = "Credenciales inválidas", content = @Content),
-        @ApiResponse(responseCode = "401", description = "No autorizado", content = @Content)
+        @ApiResponse(
+            responseCode = "400",
+            description = "Credenciales inválidas",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "401",
+            description = "No autorizado",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class)
+            )
+        )
     })
     public String login(
         @io.swagger.v3.oas.annotations.parameters.RequestBody(
@@ -64,8 +78,22 @@ public class AuthController {
                 schema = @Schema(implementation = String.class)
             )
         ),
-        @ApiResponse(responseCode = "400", description = "Datos inválidos", content = @Content),
-        @ApiResponse(responseCode = "404", description = "Usuario no encontrado", content = @Content)
+        @ApiResponse(
+            responseCode = "400",
+            description = "Datos inválidos",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "Usuario no encontrado",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class)
+            )
+        )
     })
     public String forgotPassword(
         @io.swagger.v3.oas.annotations.parameters.RequestBody(

--- a/src/main/java/com/example/usermanagement/controller/UserController.java
+++ b/src/main/java/com/example/usermanagement/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.example.usermanagement.controller;
 
+import com.example.usermanagement.dto.ErrorResponse;
 import com.example.usermanagement.dto.RegisterRequest;
 import com.example.usermanagement.dto.ResetPasswordRequest;
 import com.example.usermanagement.dto.UserResponse;
@@ -37,8 +38,22 @@ public class UserController {
                             schema = @Schema(implementation = UserResponse.class)
                     )
             ),
-            @ApiResponse(responseCode = "400", description = "Datos inválidos", content = @Content),
-            @ApiResponse(responseCode = "409", description = "El usuario ya existe", content = @Content)
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "Datos inválidos",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "409",
+                    description = "El usuario ya existe",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class)
+                    )
+            )
     })
     public UserResponse createUser(
             @io.swagger.v3.oas.annotations.parameters.RequestBody(
@@ -60,8 +75,22 @@ public class UserController {
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Contraseña restablecida", content = @Content),
-            @ApiResponse(responseCode = "400", description = "Datos inválidos", content = @Content),
-            @ApiResponse(responseCode = "404", description = "Token inválido", content = @Content)
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "Datos inválidos",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Token inválido",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class)
+                    )
+            )
     })
     public void resetPassword(
             @io.swagger.v3.oas.annotations.parameters.RequestBody(
@@ -81,8 +110,22 @@ public class UserController {
     @Operation(summary = "Lista todos los usuarios", security = @SecurityRequirement(name = "bearerAuth"))
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Usuarios listados"),
-            @ApiResponse(responseCode = "401", description = "No autorizado"),
-            @ApiResponse(responseCode = "404", description = "No se encontraron usuarios")
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "No autorizado",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "No se encontraron usuarios",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class)
+                    )
+            )
     })
     public Page<UserResponse> listUsers(@Parameter(description = "Información de paginación") Pageable pageable) {
         return userService.getUsers(pageable);
@@ -93,8 +136,22 @@ public class UserController {
     @Operation(summary = "Obtiene un usuario por ID", security = @SecurityRequirement(name = "bearerAuth"))
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Usuario encontrado"),
-            @ApiResponse(responseCode = "401", description = "No autorizado"),
-            @ApiResponse(responseCode = "404", description = "Usuario no encontrado")
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "No autorizado",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Usuario no encontrado",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class)
+                    )
+            )
     })
     public UserResponse getUser(@Parameter(description = "ID del usuario", required = true) @PathVariable Long id) {
         return userService.getUser(id);
@@ -105,8 +162,22 @@ public class UserController {
     @Operation(summary = "Actualiza un usuario existente", security = @SecurityRequirement(name = "bearerAuth"))
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Usuario actualizado"),
-            @ApiResponse(responseCode = "401", description = "No autorizado"),
-            @ApiResponse(responseCode = "404", description = "Usuario no encontrado")
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "No autorizado",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Usuario no encontrado",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class)
+                    )
+            )
     })
     public UserResponse updateUser(
             @Parameter(description = "ID del usuario", required = true) @PathVariable Long id,
@@ -120,8 +191,22 @@ public class UserController {
     @Operation(summary = "Elimina un usuario", security = @SecurityRequirement(name = "bearerAuth"))
     @ApiResponses(value = {
             @ApiResponse(responseCode = "204", description = "Usuario eliminado"),
-            @ApiResponse(responseCode = "401", description = "No autorizado"),
-            @ApiResponse(responseCode = "404", description = "Usuario no encontrado")
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "No autorizado",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Usuario no encontrado",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class)
+                    )
+            )
     })
     public void deleteUser(@Parameter(description = "ID del usuario", required = true) @PathVariable Long id) {
         userService.deleteUser(id);

--- a/src/main/java/com/example/usermanagement/dto/ErrorResponse.java
+++ b/src/main/java/com/example/usermanagement/dto/ErrorResponse.java
@@ -1,0 +1,30 @@
+package com.example.usermanagement.dto;
+
+public class ErrorResponse {
+    private int code;
+    private String message;
+
+    public ErrorResponse() {
+    }
+
+    public ErrorResponse(int code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public void setCode(int code) {
+        this.code = code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+}

--- a/src/main/java/com/example/usermanagement/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/usermanagement/exception/GlobalExceptionHandler.java
@@ -1,38 +1,30 @@
 package com.example.usermanagement.exception;
 
+import com.example.usermanagement.dto.ErrorResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-import java.util.HashMap;
-import java.util.Map;
-
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(BadCredentialsException.class)
     @ResponseStatus(HttpStatus.UNAUTHORIZED)
-    public Map<String, String> handleBadCredentials(BadCredentialsException ex) {
-        Map<String, String> map = new HashMap<>();
-        map.put("error", "Invalid credentials");
-        return map;
+    public ErrorResponse handleBadCredentials(BadCredentialsException ex) {
+        return new ErrorResponse(HttpStatus.UNAUTHORIZED.value(), "Invalid credentials");
     }
 
     @ExceptionHandler(RuntimeException.class)
     @ResponseStatus(HttpStatus.NOT_FOUND)
-    public Map<String, String> handleRuntime(RuntimeException ex) {
-        Map<String, String> map = new HashMap<>();
-        map.put("error", ex.getMessage());
-        return map;
+    public ErrorResponse handleRuntime(RuntimeException ex) {
+        return new ErrorResponse(HttpStatus.NOT_FOUND.value(), ex.getMessage());
     }
 
     @ExceptionHandler(Exception.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
-    public Map<String, String> handleOther(Exception ex) {
-        Map<String, String> map = new HashMap<>();
-        map.put("error", ex.getMessage());
-        return map;
+    public ErrorResponse handleOther(Exception ex) {
+        return new ErrorResponse(HttpStatus.BAD_REQUEST.value(), ex.getMessage());
     }
 }


### PR DESCRIPTION
## Summary
- introduce `ErrorResponse` DTO
- return `ErrorResponse` from `GlobalExceptionHandler`
- document error responses in `AuthController` and `UserController`

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c77f37cf0483239f0ce0ccfc526c85