### PR TITLE
Document 403 responses and centralize error handling

### DIFF
--- a/src/main/java/com/example/usermanagement/controller/UserController.java
+++ b/src/main/java/com/example/usermanagement/controller/UserController.java
@@ -3,6 +3,7 @@ package com.example.usermanagement.controller;
 import com.example.usermanagement.dto.RegisterRequest;
 import com.example.usermanagement.dto.ResetPasswordRequest;
 import com.example.usermanagement.dto.UserResponse;
+import com.example.usermanagement.dto.ErrorResponse;
 import com.example.usermanagement.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -82,6 +83,7 @@ public class UserController {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Usuarios listados"),
             @ApiResponse(responseCode = "401", description = "No autorizado"),
+            @ApiResponse(responseCode = "403", description = "Prohibido", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             @ApiResponse(responseCode = "404", description = "No se encontraron usuarios")
     })
     public Page<UserResponse> listUsers(@Parameter(description = "Información de paginación") Pageable pageable) {
@@ -94,6 +96,7 @@ public class UserController {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Usuario encontrado"),
             @ApiResponse(responseCode = "401", description = "No autorizado"),
+            @ApiResponse(responseCode = "403", description = "Prohibido", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             @ApiResponse(responseCode = "404", description = "Usuario no encontrado")
     })
     public UserResponse getUser(@Parameter(description = "ID del usuario", required = true) @PathVariable Long id) {
@@ -106,6 +109,7 @@ public class UserController {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Usuario actualizado"),
             @ApiResponse(responseCode = "401", description = "No autorizado"),
+            @ApiResponse(responseCode = "403", description = "Prohibido", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             @ApiResponse(responseCode = "404", description = "Usuario no encontrado")
     })
     public UserResponse updateUser(
@@ -121,6 +125,7 @@ public class UserController {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "204", description = "Usuario eliminado"),
             @ApiResponse(responseCode = "401", description = "No autorizado"),
+            @ApiResponse(responseCode = "403", description = "Prohibido", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             @ApiResponse(responseCode = "404", description = "Usuario no encontrado")
     })
     public void deleteUser(@Parameter(description = "ID del usuario", required = true) @PathVariable Long id) {

--- a/src/main/java/com/example/usermanagement/dto/ErrorResponse.java
+++ b/src/main/java/com/example/usermanagement/dto/ErrorResponse.java
@@ -1,0 +1,20 @@
+package com.example.usermanagement.dto;
+
+public class ErrorResponse {
+    private String error;
+
+    public ErrorResponse() {
+    }
+
+    public ErrorResponse(String error) {
+        this.error = error;
+    }
+
+    public String getError() {
+        return error;
+    }
+
+    public void setError(String error) {
+        this.error = error;
+    }
+}

--- a/src/main/java/com/example/usermanagement/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/usermanagement/exception/GlobalExceptionHandler.java
@@ -1,38 +1,37 @@
 package com.example.usermanagement.exception;
 
+import com.example.usermanagement.dto.ErrorResponse;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-
-import java.util.HashMap;
-import java.util.Map;
+import org.springframework.web.server.ResponseStatusException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(BadCredentialsException.class)
     @ResponseStatus(HttpStatus.UNAUTHORIZED)
-    public Map<String, String> handleBadCredentials(BadCredentialsException ex) {
-        Map<String, String> map = new HashMap<>();
-        map.put("error", "Invalid credentials");
-        return map;
+    public ErrorResponse handleBadCredentials(BadCredentialsException ex) {
+        return new ErrorResponse("Invalid credentials");
     }
 
     @ExceptionHandler(RuntimeException.class)
     @ResponseStatus(HttpStatus.NOT_FOUND)
-    public Map<String, String> handleRuntime(RuntimeException ex) {
-        Map<String, String> map = new HashMap<>();
-        map.put("error", ex.getMessage());
-        return map;
+    public ErrorResponse handleRuntime(RuntimeException ex) {
+        return new ErrorResponse(ex.getMessage());
     }
 
     @ExceptionHandler(Exception.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
-    public Map<String, String> handleOther(Exception ex) {
-        Map<String, String> map = new HashMap<>();
-        map.put("error", ex.getMessage());
-        return map;
+    public ErrorResponse handleOther(Exception ex) {
+        return new ErrorResponse(ex.getMessage());
+    }
+
+    @ExceptionHandler(ResponseStatusException.class)
+    public ResponseEntity<ErrorResponse> handleResponseStatus(ResponseStatusException ex) {
+        return ResponseEntity.status(ex.getStatusCode()).body(new ErrorResponse(ex.getReason()));
     }
 }


### PR DESCRIPTION
## Summary
- Document HTTP 403 Forbidden responses for protected user endpoints
- Centralize error handling with a reusable `ErrorResponse` and support for `ResponseStatusException`

## Testing
- `mvn -q -e -DskipTests package` *(fails: Network is unreachable)*
- `mvn -q -e springdoc-openapi:generate` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c77f4dcd488323b4fbffbfe0d0f11e