### PR TITLE
Allow unauthenticated password reset patch

### DIFF
--- a/src/main/java/com/example/usermanagement/security/SecurityConfig.java
+++ b/src/main/java/com/example/usermanagement/security/SecurityConfig.java
@@ -52,7 +52,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/auth/**").permitAll()
                         // registro y restablecimiento de usuarios
                         .requestMatchers(HttpMethod.POST, "/api/users").permitAll()
-                        .requestMatchers(HttpMethod.POST, "/api/users/reset").permitAll()
+                        .requestMatchers(HttpMethod.PATCH, "/api/users/password").permitAll()
 
                         // todo lo demás requiere token
                         .requestMatchers("/api/users/**").authenticated()


### PR DESCRIPTION
## Summary
- update security configuration to permit PATCH /api/users/password without authentication
- remove unused POST /api/users/reset matcher

## Testing
- `mvn clean package` *(fails: unable to reach Maven Central from execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1cd4fee80832398df2dd73c027cdd